### PR TITLE
fix(next-pwa): fixed `__PWA_SW_ENTRY_WORKER__` being undefined

### DIFF
--- a/.changeset/short-ducks-glow.md
+++ b/.changeset/short-ducks-glow.md
@@ -1,0 +1,7 @@
+---
+"@ducanh2912/next-pwa": patch
+---
+
+fix(next-pwa): fixed `__PWA_SW_ENTRY_WORKER__` being undefined
+
+- This happens when `cacheOnFrontEndNav` is not enabled, which causes `webpack.DefinePlugin` to not be called.

--- a/packages/next-pwa/src/build-sw-entry-worker.ts
+++ b/packages/next-pwa/src/build-sw-entry-worker.ts
@@ -16,11 +16,16 @@ export const buildSWEntryWorker = ({
   id,
   destDir,
   minify,
+  shouldGenSWEWorker,
 }: {
   id: string;
   destDir: string;
   minify: boolean;
+  shouldGenSWEWorker: boolean;
 }) => {
+  if (!shouldGenSWEWorker) {
+    return undefined;
+  }
   const name = `sw-entry-worker-${id}.js`;
   const swEntryWorkerEntry = path.join(__dirname, `sw-entry-worker.js`);
 

--- a/packages/next-pwa/src/index.ts
+++ b/packages/next-pwa/src/index.ts
@@ -159,18 +159,18 @@ const withPWAInit = (pluginOptions: PluginOptions = {}): WithPWA => {
 
         if (!options.isServer) {
           const _dest = path.join(options.dir, dest);
+          const sweWorkerName = buildSWEntryWorker({
+            id: buildId,
+            destDir: _dest,
+            minify: !dev,
+            shouldGenSWEWorker: cacheOnFrontEndNav,
+          });
 
-          if (cacheOnFrontEndNav) {
-            config.plugins.push(
-              new webpack.DefinePlugin({
-                __PWA_SW_ENTRY_WORKER__: `'${buildSWEntryWorker({
-                  id: buildId,
-                  destDir: _dest,
-                  minify: !dev,
-                })}'`,
-              })
-            );
-          }
+          config.plugins.push(
+            new webpack.DefinePlugin({
+              __PWA_SW_ENTRY_WORKER__: sweWorkerName && `'${sweWorkerName}'`,
+            })
+          );
 
           const customWorkerScriptName = buildCustomWorker({
             id: buildId,


### PR DESCRIPTION
This happens when `cacheOnFrontEndNav` is not enabled, which causes `webpack.DefinePlugin` to not be called.