### PR TITLE
feat: added `watchWorkersInDev`, added `.webm` to `defaultCache`'s `static-video-assets`

### DIFF
--- a/.changeset/soft-schools-battle.md
+++ b/.changeset/soft-schools-battle.md
@@ -1,0 +1,7 @@
+---
+"@ducanh2912/next-pwa": minor
+---
+
+feat: added `watchWorkersInDev`
+
+- Note that this feature is disabled by default, and can be enabled by setting `PluginOptions.watchWorkersInDev` to `true`. After a change is detected and `webpack` rebuilds the custom worker, you have to reload the page for it to take effect.

--- a/.changeset/weak-tables-roll.md
+++ b/.changeset/weak-tables-roll.md
@@ -1,0 +1,7 @@
+---
+"@ducanh2912/next-pwa": minor
+---
+
+feat: added `.webm` to `defaultCache`'s `static-video-assets`
+
+- I think it'd be nice to support this extension as well, and this shouldn't cause a breaking change (if there is another entry that matches `.webm` files in `workboxOptions.runtimeCaching` and `extendDefaultRuntimeCaching`, then Workbox will still pick that entry).

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yaml
@@ -2,6 +2,8 @@ name: Feature request
 description: Create a feature request
 title: "[Feature request]: "
 labels: ["feature-request", "triage"]
+assignees:
+  - DuCanhGH
 body:
   - type: markdown
     attributes:

--- a/docs/content/next-pwa/configuring.mdx
+++ b/docs/content/next-pwa/configuring.mdx
@@ -95,6 +95,8 @@ export default withPWA({
 
 - `reloadOnOnline` — Reload the app when it has gone back online.
 
+- `watchWorkersInDev` — Watch certain workers for file changes in development mode. This currently includes the custom worker.
+
 ## Other options
 
 `next-pwa` uses `workbox-webpack-plugin` under the hood, other options can be found in the documentation for [GenerateSW](https://developer.chrome.com/docs/workbox/modules/workbox-webpack-plugin/#generatesw-plugin) and

--- a/examples/custom-worker/shared/utils/index.ts
+++ b/examples/custom-worker/shared/utils/index.ts
@@ -1,5 +1,5 @@
-export function util(message: string) {
-  console.log("Hello from util.");
+export function utils(message: string) {
+  console.log("Hello from utils.");
   console.log("es6+ syntax test:");
   // eslint-disable-next-line prefer-const
   let foo = { message: message };

--- a/examples/custom-worker/worker/index.ts
+++ b/examples/custom-worker/worker/index.ts
@@ -1,5 +1,5 @@
 import { message } from "@shared/constants.ts";
-import { util } from "@shared/utils/index.ts";
+import { utils } from "@shared/utils/index.ts";
 
 declare const self: ServiceWorkerGlobalScope;
 
@@ -8,7 +8,7 @@ declare const self: ServiceWorkerGlobalScope;
 //
 // self.__WB_DISABLE_DEV_LOGS = true
 
-util(message);
+utils(message);
 
 // listen to message event from window
 self.addEventListener("message", (event) => {

--- a/packages/next-pwa/src/cache.ts
+++ b/packages/next-pwa/src/cache.ts
@@ -81,7 +81,7 @@ const defaultCache: RuntimeCaching[] = [
     },
   },
   {
-    urlPattern: /\.(?:mp4)$/i,
+    urlPattern: /\.(?:mp4|webm)$/i,
     handler: "CacheFirst",
     options: {
       rangeRequests: true,

--- a/packages/next-pwa/src/index.ts
+++ b/packages/next-pwa/src/index.ts
@@ -87,6 +87,7 @@ const withPWAInit = (
         extendDefaultRuntimeCaching = false,
         swcMinify = nextConfig.swcMinify ?? nextDefConfig?.swcMinify ?? false,
         browserslist = "chrome >= 56",
+        watchWorkersInDev = false,
       } = pluginOptions;
 
       if (typeof nextConfig.webpack === "function") {
@@ -150,6 +151,7 @@ const withPWAInit = (
         setDefaultContext("shouldMinify", !dev);
         setDefaultContext("useSwcMinify", swcMinify);
         setDefaultContext("browserslist", browserslist);
+        setDefaultContext("devWatchWorkers", watchWorkersInDev);
 
         const _dest = path.join(options.dir, dest);
         const _cwdest = path.join(options.dir, customWorkerDest);

--- a/packages/next-pwa/src/resolve-workbox-plugin.ts
+++ b/packages/next-pwa/src/resolve-workbox-plugin.ts
@@ -9,7 +9,7 @@ import { resolveRuntimeCaching } from "./resolve-runtime-caching.js";
 import type { WorkboxCommon } from "./resolve-workbox-common.js";
 import type { PluginOptions } from "./types.js";
 import { isInjectManifestConfig, overrideAfterCalledMethod } from "./utils.js";
-import { NextPWAContext } from "./webpack-builders/context.js";
+import { nextPWAContext } from "./webpack-builders/context.js";
 
 type PluginCompleteOptions = Required<
   Pick<PluginOptions, "extendDefaultRuntimeCaching" | "dynamicStartUrl">
@@ -40,17 +40,17 @@ export const resolveWorkboxPlugin = ({
   hasFallbacks: boolean;
 } & PluginCompleteOptions) => {
   if (!workboxOptions.babelPresetEnvTargets) {
-    switch (typeof NextPWAContext.browserslist) {
+    switch (typeof nextPWAContext.browserslist) {
       case "string":
-        workboxOptions.babelPresetEnvTargets = [NextPWAContext.browserslist];
+        workboxOptions.babelPresetEnvTargets = [nextPWAContext.browserslist];
         break;
       case "object": {
-        if (Array.isArray(NextPWAContext.browserslist)) {
-          workboxOptions.babelPresetEnvTargets = NextPWAContext.browserslist;
+        if (Array.isArray(nextPWAContext.browserslist)) {
+          workboxOptions.babelPresetEnvTargets = nextPWAContext.browserslist;
         } else {
           workboxOptions.babelPresetEnvTargets = [];
           for (const [browser, minimumVersion] of Object.entries(
-            NextPWAContext.browserslist
+            nextPWAContext.browserslist
           )) {
             workboxOptions.babelPresetEnvTargets.push(
               `${browser} >= ${minimumVersion}`

--- a/packages/next-pwa/src/types.ts
+++ b/packages/next-pwa/src/types.ts
@@ -4,10 +4,118 @@ import type { BrowserslistOptions, WorkboxTypes } from "./private-types.js";
 
 export interface PluginOptions {
   /**
+   * Cache every `<link rel="stylesheet" />` and `<script />` on frontend navigation.
+   * Requires `cacheOnFrontEndNav` to be enabled.
+   * @default false
+   */
+  aggressiveFrontEndNavCaching?: boolean;
+  /**
+   * Configure supported browsers using Browserslist.
+   * @default "chrome >= 56"
+   */
+  browserslist?: BrowserslistOptions;
+  /**
+   * One or more specifiers used to exclude assets from the precache manifest.
+   * This is interpreted following the same rules as Webpack's standard `exclude`
+   * option. Relative to `.next/static` or your custom build folder. Defaults to
+   * [].
+   * @example
+   *   ```ts
+   *   [/chunks\/images\/.*$/];
+   *   ```
+   * @default
+   *   ```ts
+   *   [];
+   *   ```
+   */
+  buildExcludes?: GenerateSWConfig["exclude"];
+  /**
+   * Enable additional route caching when users navigate through pages with
+   * `next/link`. This improves user experience in some cases but it
+   * also adds some overhead because of additional network calls.
+   * @default false
+   */
+  cacheOnFrontEndNav?: boolean;
+  /**
+   * Turn on caching for the start URL. [Discussion on use cases for this
+   * option](https://github.com/shadowwalker/next-pwa/pull/296#issuecomment-1094167025)
+   * @default true
+   */
+  cacheStartUrl?: boolean;
+  /**
+   * The output directory of the custom worker.
+   * @default dest
+   */
+  customWorkerDest?: string;
+  // NEXT-PWA-TODO(major): remove this option
+  /**
+   * @deprecated renamed to `customWorkerSrc`, to be removed next major version.
+   */
+  customWorkerDir?: string;
+  /**
+   * The custom worker's output filename prefix.
+   * @default "worker"
+   */
+  customWorkerPrefix?: string;
+  /**
+   * Change the directory in which `next-pwa` looks for a custom worker
+   * implementation to import into the service worker. Relative to the root or `src`
+   * directory.
+   * @default "worker"
+   */
+  customWorkerSrc?: string;
+  // NEXT-PWA-TODO(major): change this option's default to `"public"`
+  /**
+   * Set the output directory for service worker. Relative to Next.js's root
+   * directory. By default, this plugin uses `.next`, but it is recommended to
+   * change it to `public` instead.
+   * @default ".next"
+   */
+  dest?: string;
+  /**
    * Whether `next-pwa` should be disabled.
    * @default false
    */
   disable?: boolean;
+  /**
+   * If your start URL returns different HTML documents under different states
+   * (such as logged in and not logged in), this should be set to true if you
+   * also use `cacheStartUrl`. Effective only when `cacheStartUrl` is set to `true`.
+   * Set to `false` if your start URL always returns same HTML document, in which case
+   * the start URL will be precached, helping speed up the first load.
+   * @default true
+   */
+  dynamicStartUrl?: boolean;
+  /**
+   * If your start URL redirects to another route such as `/login`, it's
+   * recommended to specify this redirected URL for the best user experience.
+   * Effective when `dynamicStartUrl` is set to `true`.
+   * @default undefined
+   */
+  dynamicStartUrlRedirect?: string;
+  /**
+   * Extend the default `runtimeCaching` array when `runtimeCaching` is specified.
+   * Entries having the same `cacheName` as any entry in the default `runtimeCaching`
+   * array will override it.
+   * @default false
+   */
+  extendDefaultRuntimeCaching?: boolean;
+  /**
+   * Configure routes to be precached so that they can be used as a fallback when
+   * fetching a resource from both the cache and the network fails. If you just need
+   * a fallback document, simply create `pages/_offline.tsx` or `app/~offline/page.tsx`.
+   */
+  fallbacks?: FallbackRoutes;
+  /**
+   * An array of glob pattern strings to exclude files in the public folder from
+   * being precached. By default, this plugin excludes `public/noprecache`.
+   * Note that you have to add `!` before each glob pattern for it to work.
+   * @example
+   *   ```ts
+   *   ["!img/super-large-image.jpg", "!fonts/not-used-fonts.otf"];
+   *   ```
+   */
+  publicExcludes?: string[];
   /**
    * Allow this plugin to automatically register the service worker for you. Set
    * this to `false` if you want to register the service worker yourself, which
@@ -57,144 +165,47 @@ export interface PluginOptions {
    * @default true
    */
   register?: boolean;
-  // NEXT-PWA-TODO(major): change this option's default to `"public"`
-  /**
-   * Set the output directory for service worker. Relative to Next.js's root
-   * directory. By default, this plugin uses `.next`, but it is recommended to
-   * change it to `public` instead.
-   * @default ".next"
-   */
-  dest?: string;
-  /**
-   * The service worker's output filename.
-   * @default "/sw.js"
-   */
-  sw?: string;
-  /**
-   * Turn on caching for the start URL. [Discussion on use cases for this
-   * option](https://github.com/shadowwalker/next-pwa/pull/296#issuecomment-1094167025)
-   * @default true
-   */
-  cacheStartUrl?: boolean;
-  /**
-   * If your start URL returns different HTML documents under different states
-   * (such as logged in and not logged in), this should be set to true if you
-   * also use `cacheStartUrl`. Effective only when `cacheStartUrl` is set to `true`.
-   * Set to `false` if your start URL always returns same HTML document, in which case
-   * the start URL will be precached, helping speed up the first load.
-   * @default true
-   */
-  dynamicStartUrl?: boolean;
-  /**
-   * If your start URL redirects to another route such as `/login`, it's
-   * recommended to specify this redirected URL for the best user experience.
-   * Effective when `dynamicStartUrl` is set to `true`.
-   * @default undefined
-   */
-  dynamicStartUrlRedirect?: string;
-  /**
-   * An array of glob pattern strings to exclude files in the public folder from
-   * being precached. By default, this plugin excludes `public/noprecache`.
-   * Note that you have to add `!` before each glob pattern for it to work.
-   * @example
-   *   ```ts
-   *   ["!img/super-large-image.jpg", "!fonts/not-used-fonts.otf"];
-   *   ```
-   */
-  publicExcludes?: string[];
-  /**
-   * One or more specifiers used to exclude assets from the precache manifest.
-   * This is interpreted following the same rules as Webpack's standard `exclude`
-   * option. Relative to `.next/static` or your custom build folder. Defaults to
-   * [].
-   * @example
-   *   ```ts
-   *   [/chunks\/images\/.*$/];
-   *   ```
-   * @default
-   *   ```ts
-   *   [];
-   *   ```
-   */
-  buildExcludes?: GenerateSWConfig["exclude"];
-  /**
-   * Configure routes to be precached so that they can be used as a fallback when
-   * fetching a resource from both the cache and the network fails. If you just need
-   * a fallback document, simply create `pages/_offline.tsx` or `app/~offline/page.tsx`.
-   */
-  fallbacks?: FallbackRoutes;
-  /**
-   * Enable additional route caching when users navigate through pages with
-   * `next/link`. This improves user experience in some cases but it
-   * also adds some overhead because of additional network calls.
-   * @default false
-   */
-  cacheOnFrontEndNav?: boolean;
-  /**
-   * Cache every `<link rel="stylesheet" />` and `<script />` on frontend navigation.
-   * Requires `cacheOnFrontEndNav` to be enabled.
-   * @default false
-   */
-  aggressiveFrontEndNavCaching?: boolean;
-  /**
-   * URL scope for PWA. Set to `/foo/` so that paths under `/foo/` are PWA while others
-   * are not.
-   * @default nextConfig.basePath
-   */
-  scope?: string;
-  // NEXT-PWA-TODO(major): remove this option
-  /**
-   * @deprecated renamed to `customWorkerSrc`, to be removed next major version.
-   */
-  customWorkerDir?: string;
-  /**
-   * Change the directory in which `next-pwa` looks for a custom worker
-   * implementation to import into the service worker. Relative to the root or `src`
-   * directory.
-   * @default "worker"
-   */
-  customWorkerSrc?: string;
-  /**
-   * The output directory of the custom worker.
-   * @default dest
-   */
-  customWorkerDest?: string;
-  /**
-   * The custom worker's output filename prefix.
-   * @default "worker"
-   */
-  customWorkerPrefix?: string;
   /**
    * Reload the app when it has gone back online.
    * @default true
    */
   reloadOnOnline?: boolean;
   /**
-   * Pass options to `workbox-webpack-plugin`. This one relies on
-   * `workbox-webpack-plugin`'s own JSDoc, so some information may not be
-   * exactly correct.
+   * URL scope for PWA. Set to `/foo/` so that paths under `/foo/` are PWA while others
+   * are not.
+   * @default nextConfig.basePath
    */
-  workboxOptions?: WorkboxTypes[keyof WorkboxTypes];
+  scope?: string;
   /**
-   * Extend the default `runtimeCaching` array when `runtimeCaching` is specified.
-   * Entries having the same `cacheName` as any entry in the default `runtimeCaching`
-   * array will override it.
-   * @default false
+   * The service worker's output filename.
+   * @default "/sw.js"
    */
-  extendDefaultRuntimeCaching?: boolean;
+  sw?: string;
   /**
    * Use [`swc`](https://swc.rs) to minify the custom worker, the fallback worker, and more.
    * @default nextConfig.swcMinify
    */
   swcMinify?: boolean;
   /**
-   * Configure supported browsers using Browserslist.
-   * @default "chrome >= 56"
+   * Watch certain workers for file changes in development mode. This currently includes the
+   * custom worker.
+   * @default false
    */
-  browserslist?: BrowserslistOptions;
+  watchWorkersInDev?: boolean;
+  /**
+   * Pass options to `workbox-webpack-plugin`. This one relies on
+   * `workbox-webpack-plugin`'s own JSDoc, so some information may not be
+   * exactly correct.
+   */
+  workboxOptions?: WorkboxTypes[keyof WorkboxTypes];
 }
 
 export interface FallbackRoutes {
+  /**
+   * Fallback route for audios, defaults to none.
+   * @default undefined
+   */
+  audio?: string;
   /**
    * Fallback route for document (pages).
    * @default
@@ -209,23 +220,18 @@ export interface FallbackRoutes {
    */
   data?: string;
   /**
+   * Fallback route for fonts, defaults to none.
+   * @default undefined
+   */
+  font?: string;
+  /**
    * Fallback route for images, defaults to none.
    * @default undefined
    */
   image?: string;
   /**
-   * Fallback route for audios, defaults to none.
-   * @default undefined
-   */
-  audio?: string;
-  /**
    * Fallback route for videos, defaults to none.
    * @default undefined
    */
   video?: string;
-  /**
-   * Fallback route for fonts, defaults to none.
-   * @default undefined
-   */
-  font?: string;
 }

--- a/packages/next-pwa/src/types.ts
+++ b/packages/next-pwa/src/types.ts
@@ -117,6 +117,22 @@ export interface PluginOptions {
    */
   publicExcludes?: string[];
   /**
+   * URL scope for PWA. Set to `/foo/` so that paths under `/foo/` are PWA while others
+   * are not.
+   * @default nextConfig.basePath
+   */
+  scope?: string;
+  /**
+   * The service worker's output filename.
+   * @default "/sw.js"
+   */
+  sw?: string;
+  /**
+   * Use [`swc`](https://swc.rs) to minify the custom worker, the fallback worker, and more.
+   * @default nextConfig.swcMinify
+   */
+  swcMinify?: boolean;
+  /**
    * Allow this plugin to automatically register the service worker for you. Set
    * this to `false` if you want to register the service worker yourself, which
    * can be done by running `window.workbox.register()` in
@@ -170,22 +186,6 @@ export interface PluginOptions {
    * @default true
    */
   reloadOnOnline?: boolean;
-  /**
-   * URL scope for PWA. Set to `/foo/` so that paths under `/foo/` are PWA while others
-   * are not.
-   * @default nextConfig.basePath
-   */
-  scope?: string;
-  /**
-   * The service worker's output filename.
-   * @default "/sw.js"
-   */
-  sw?: string;
-  /**
-   * Use [`swc`](https://swc.rs) to minify the custom worker, the fallback worker, and more.
-   * @default nextConfig.swcMinify
-   */
-  swcMinify?: boolean;
   /**
    * Watch certain workers for file changes in development mode. This currently includes the
    * custom worker.

--- a/packages/next-pwa/src/webpack-builders/context.ts
+++ b/packages/next-pwa/src/webpack-builders/context.ts
@@ -15,27 +15,32 @@ interface NextPWAContext {
   shouldMinify: boolean | undefined;
   useSwcMinify: boolean | undefined;
   browserslist: BrowserslistOptions | undefined;
+  devWatchWorkers: boolean | undefined;
 }
 
-export const NextPWAContext: NextPWAContext = {
+export const nextPWAContext: NextPWAContext = {
   shouldMinify: resolveContextEnv(process.env.NEXT_PWA_MINIFY, convertBoolean),
   useSwcMinify: resolveContextEnv(
     process.env.NEXT_PWA_SWC_MINIFY,
     convertBoolean
   ),
   browserslist: undefined,
+  devWatchWorkers: resolveContextEnv(
+    process.env.NEXT_PWA_DEV_WATCH,
+    convertBoolean
+  ),
 };
 
 /**
- * Set default value for a key in `NextPWAContext`.
- * @param key The key in `NextPWAContext`
+ * Set default value for a key in `nextPWAContext`.
+ * @param key The key in `nextPWAContext`
  * @param value The value
  */
-export const setDefaultContext = <T extends keyof typeof NextPWAContext>(
+export const setDefaultContext = <T extends keyof NextPWAContext>(
   key: T,
-  value: (typeof NextPWAContext)[T]
+  value: NextPWAContext[T]
 ) => {
-  if (NextPWAContext[key] === undefined || NextPWAContext[key] === null) {
-    NextPWAContext[key] = value;
+  if (nextPWAContext[key] === undefined || nextPWAContext[key] === null) {
+    nextPWAContext[key] = value;
   }
 };

--- a/packages/next-pwa/src/webpack-builders/utils.ts
+++ b/packages/next-pwa/src/webpack-builders/utils.ts
@@ -9,7 +9,7 @@ import type { Configuration } from "webpack";
 
 import { assertValue } from "../utils.js";
 import { defaultSwcRc } from "./.swcrc.js";
-import { NextPWAContext } from "./context.js";
+import { nextPWAContext } from "./context.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -32,7 +32,7 @@ const resolveTerserOptions = (): MinimizerOptions<TerserOptions> & {
     ascii_only: true,
   },
   resolveSwc,
-  useSwcMinify: NextPWAContext.useSwcMinify,
+  useSwcMinify: nextPWAContext.useSwcMinify,
 });
 
 interface SharedWebpackConfigOptions {
@@ -42,7 +42,7 @@ interface SharedWebpackConfigOptions {
 export const getSharedWebpackConfig = ({
   swcRc = defaultSwcRc,
 }: SharedWebpackConfigOptions): Configuration => {
-  const optimization = NextPWAContext.shouldMinify && {
+  const optimization = nextPWAContext.shouldMinify && {
     minimize: true,
     minimizer: [
       new TerserPlugin({
@@ -52,13 +52,13 @@ export const getSharedWebpackConfig = ({
     ],
   };
   assertValue(
-    NextPWAContext.browserslist !== undefined,
+    nextPWAContext.browserslist !== undefined,
     "Browserslist config is not defined. This is most likely a bug."
   );
   if (!swcRc.env) {
     swcRc.env = {};
   }
-  swcRc.env.targets = NextPWAContext.browserslist;
+  swcRc.env.targets = nextPWAContext.browserslist;
   return {
     resolve: {
       extensions: [".js", ".ts"],


### PR DESCRIPTION
## Fixes:
- Fixes #88
- Fixes #89

## Changes:
- Added `watchWorkersInDev`

  - Note that this feature is disabled by default, and can be enabled by setting `PluginOptions.watchWorkersInDev` to `true`. After a change is detected and `webpack` rebuilds the custom worker, you have to reload the page for it to take effect.

- Added `.webm` to `defaultCache`'s `static-video-assets`

  - I think it'd be nice to support this extension as well, and this shouldn't cause a breaking change (if there is another entry that matches `.webm` files in `workboxOptions.runtimeCaching` and `extendDefaultRuntimeCaching`, then Workbox will still pick that entry).

## Todo:
- Investigate issue 79 (seems pretty hard to produce unfortunately)