### PR TITLE
fix(next-auth): allow users to use the application offline

### DIFF
--- a/.changeset/honest-dots-grow.md
+++ b/.changeset/honest-dots-grow.md
@@ -1,0 +1,5 @@
+---
+"@ducanh2912/next-pwa": patch
+---
+
+fix(next-auth): allow users to use the application offline

--- a/packages/next-pwa/src/cache.ts
+++ b/packages/next-pwa/src/cache.ts
@@ -141,7 +141,7 @@ const defaultCache: RuntimeCaching[] = [
       // Exclude /api/auth/callback/* to fix OAuth workflow in Safari without having an impact on other environments
       // The above route is the default for next-auth, you may need to change it if your OAuth workflow has a different callback route
       // Issue: https://github.com/shadowwalker/next-pwa/issues/131#issuecomment-821894809
-      if (!sameOrigin || pathname.startsWith("/api/auth/")) {
+      if (!sameOrigin || pathname.startsWith("/api/auth/callback")) {
         return false;
       }
 


### PR DESCRIPTION
Why this changes is necessary
---

Users currently face authorization issues when accessing next-pwa based application while being offline.

Suggested changes
---

- Update the list of next-auth URLs excluded from caching by making it more specific: `/api/auth/` => `/api/auth/callback/`.

Tested
---

Providers:
- Google Auth

Browsers: 
- macOS 14.0 arm64: Chrome 119 and Safari 17.0
- iOS 17.1.1: Safari in standalone mode

Actions:
- service worker available
- app available online and offline
- auth will be preserved while user offline
- login works
- logout works